### PR TITLE
Update dockefile to fix image build error

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -8,7 +8,8 @@ FROM ubuntu:16.04
 RUN apt-get update \
 	&& apt-get install python3-pip -y\
 	&& apt-get install tesseract-ocr -y\
-	&& apt-get install python3-pil -y
+	&& apt-get install python3-pil -y\
+	&& apt-get install libxml2-dev libxslt-dev zlib1g-dev -y
 
 ADD domainhunter.py /
 ADD requirements.txt /


### PR DESCRIPTION
This pull request fixes multiple errors that occur when building the image using the dockerfile

Building the image after fixes:
```
$ docker build -t domainhunter .
[+] Building 1.2s (11/11) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                 0.0s
 => => transferring dockerfile: 37B                                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                      0.0s
 => [internal] load metadata for docker.io/library/ubuntu:16.04                                                                                      1.1s
 => [auth] library/ubuntu:pull token for registry-1.docker.io                                                                                        0.0s
 => [1/5] FROM docker.io/library/ubuntu:16.04@sha256:0f71fa8d4d2d4292c3c617fda2b36f6dabe5c8b6e34c3dc5b0d17d4e704bd39c                                0.0s
 => [internal] load build context                                                                                                                    0.0s
 => => transferring context: 73B                                                                                                                     0.0s
 => CACHED [2/5] RUN apt-get update  && apt-get install python3-pip -y && apt-get install tesseract-ocr -y && apt-get install python3-pil -y && apt  0.0s
 => CACHED [3/5] ADD domainhunter.py /                                                                                                               0.0s
 => CACHED [4/5] ADD requirements.txt /                                                                                                              0.0s
 => CACHED [5/5] RUN pip3 install -r requirements.txt                                                                                                0.0s
 => exporting to image                                                                                                                               0.0s
 => => exporting layers                                                                                                                              0.0s
 => => writing image sha256:e7e247e7ee9d78ce34972460e9b8a19ad493042daa0ec2b3605a9a42373451bc                                                         0.0s
 => => naming to docker.io/library/domainhunter
 ```

Running the image after fixes:
```
$ docker run -it domainhunter

 ____   ___  __  __    _    ___ _   _   _   _ _   _ _   _ _____ _____ ____
|  _ \ / _ \|  \/  |  / \  |_ _| \ | | | | | | | | | \ | |_   _| ____|  _ \
| | | | | | | |\/| | / _ \  | ||  \| | | |_| | | | |  \| | | | |  _| | |_) |
| |_| | |_| | |  | |/ ___ \ | || |\  | |  _  | |_| | |\  | | | | |___|  _ <
|____/ \___/|_|  |_/_/   \_\___|_| \_| |_| |_|\___/|_| \_| |_| |_____|_| \_\

Expired Domains Reputation Checker
Authors: @joevest and @andrewchiles

DISCLAIMER: This is for educational purposes only!
It is designed to promote education and the improvement of computer/cyber security.
The authors or employers are not liable for any illegal act or misuse performed by any user of this tool.
If you plan to use this content for illegal purpose, don't.  Have a nice day :)

[-] Error: ExpiredDomains.net requires a username! Use the --username parameter
```