### PR TITLE
Fix the login failed issue

### DIFF
--- a/domainhunter.py
+++ b/domainhunter.py
@@ -376,7 +376,7 @@ def drawTable(header,data):
 def loginExpiredDomains():
     """Login to the ExpiredDomains site with supplied credentials"""
 
-    data = "login=%s&password=%s&redirect_2_url=/" % (username, password)
+    data = "login=%s&password=%s&redirect_2_url=/begin" % (username, password)
     headers["Content-Type"] = "application/x-www-form-urlencoded"
     r = s.post(expireddomainHost + "/login/", headers=headers, data=data, proxies=proxies, verify=False, allow_redirects=False)
     cookies = s.cookies.get_dict()


### PR DESCRIPTION
Adding `/begin` in the POST request for the login. Without we couldn't login to expired domain : March 18, 2022

![2022-03-18_10-12-13](https://user-images.githubusercontent.com/838845/159019047-54727819-d4bc-4016-a038-7deb3a2fab0c.png)

